### PR TITLE
[PROD-3490] Update node version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,7 @@ outputs:
   version_tag:
     description: 'The version string used to create the tag.'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'
 branding:
   icon: 'tag'


### PR DESCRIPTION
Updating specified Node version to prevent ongoing build warnings.   

Note: I plan to make this a major version change to keep it in line with how GH has been doing their Node version updates.  However, I do not expect this to be an actual breaking change.